### PR TITLE
Added README.md to rest-from-.net

### DIFF
--- a/samples/rest-from-.net/README.md
+++ b/samples/rest-from-.net/README.md
@@ -1,0 +1,11 @@
+## REST from .NET
+
+This sample application was developed in .NET 4.5.
+
+Referenced Assemblies:
+- System.Net.Http.2.0.20126.16343\lib\net40\System.Net.Http.dll
+- System.Net.Http.Formatting.Extension.5.2.3.0\lib\System.Net.Http.Extensions.dll
+- System.Net.Http.Formatting.Extension.5.2.3.0\lib\System.Net.Http.Formatting.dll
+- System.Net.Http.Formatting.Extension.5.2.3.0\lib\System.Net.Http.Primitives.dll
+
+


### PR DESCRIPTION
To eliminate some bug reports, a README.md was added to the project stating what version of .NET was used to build thee project. Also what reference versions are required.
I ran into an issue where I have a more recent version of one of the assemblies. If there was a notation stating what is required to build and run the sample code, I wouldn't have submitted bug reports.

Going forward, there should me a README with every sample project.  