### PR TITLE
Adds AsyncExtensions for queries

### DIFF
--- a/samples/code-samples/Queries/AsyncExtensions.cs
+++ b/samples/code-samples/Queries/AsyncExtensions.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Azure.Documents.Linq;
+
+namespace DocumentDB.Samples.Queries
+{
+    public static class AsyncExtensions
+    {
+        public static async Task<IEnumerable<T>> QueryAsync<T>(this IQueryable<T> query)
+        {
+            var documentQuery = query.AsDocumentQuery();
+            var batches = new List<T>();
+
+            do
+            {
+                batches.AddRange((await documentQuery.ExecuteNextAsync<T>()).ToList());
+            } while (documentQuery.HasMoreResults);
+
+            return batches;
+        }
+
+        public static async Task<T> FirstOrDefaultAsync<T>(this IQueryable<T> query)
+        {
+            var documentQuery = query.Take(1).AsDocumentQuery();
+            return (await documentQuery.ExecuteNextAsync<T>()).ToList().FirstOrDefault();
+        }
+    }
+}

--- a/samples/code-samples/Queries/Program.cs
+++ b/samples/code-samples/Queries/Program.cs
@@ -84,6 +84,7 @@
             
             // Querying for all documents
             QueryAllDocuments(collection.SelfLink);
+            await QueryAllDocumentsAsync(collection.SelfLink);
 
             // Querying for equality using ==
             QueryWithEquality(collection.SelfLink);
@@ -134,6 +135,23 @@
 
             // SQL
             families = client.CreateDocumentQuery<Family>(collectionLink, "SELECT * FROM Families", DefaultOptions);
+            Assert("Expected two families", families.ToList().Count == 2);
+        }
+
+        private static async Task QueryAllDocumentsAsync(string collectionLink)
+        {
+            // LINQ Query
+            var families = await
+                (from f in client.CreateDocumentQuery<Family>(collectionLink, DefaultOptions)
+                select f).QueryAsync();
+            Assert("Expected two families", families.ToList().Count == 2);
+
+            // LINQ Lambda
+            families = await client.CreateDocumentQuery<Family>(collectionLink, DefaultOptions).QueryAsync();
+            Assert("Expected two families", families.ToList().Count == 2);
+
+            // SQL
+            families = await client.CreateDocumentQuery<Family>(collectionLink, "SELECT * FROM Families", DefaultOptions).QueryAsync();
             Assert("Expected two families", families.ToList().Count == 2);
         }
 

--- a/samples/code-samples/Queries/Queries.csproj
+++ b/samples/code-samples/Queries/Queries.csproj
@@ -62,6 +62,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AsyncExtensions.cs" />
     <Compile Include="Program.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
shows how to use `IQueryable.AsDocumentQuery()` with `ExecuteNextAsync()` and `HasMoreResults` to execute queries asynchronously.
