### PR TITLE
change RunDemoAsync

### DIFF
--- a/samples/code-samples/ChangeFeed/Program.cs
+++ b/samples/code-samples/ChangeFeed/Program.cs
@@ -61,7 +61,7 @@
             collectionDefinition.PartitionKey.Paths.Add("/deviceId");
 
             await client.CreateDocumentCollectionIfNotExistsAsync(
-                UriFactory.CreateDocumentCollectionUri(databaseId, collectionId),
+                UriFactory.CreateDatabaseUri(databaseId),
                 collectionDefinition,
                 new RequestOptions { OfferThroughput = 2500 });
 


### PR DESCRIPTION
Using ```CreateDocumentCollectionUri``` raises an exception as follows

```
ResourceType Collection is unexpected. ActivityId: 4591f9c4-6fbb-4d5f-8830-f94f25d39751
```

I changed it to use ```CreateDatabaseUri``` and fixed it.