### PR TITLE
Set taskCount minimum to 1

### DIFF
--- a/samples/documentdb-benchmark/Program.cs
+++ b/samples/documentdb-benchmark/Program.cs
@@ -143,12 +143,9 @@
 
             if (degreeOfParallelism == -1)
             {
-                // set TaskCount = 10 for each 10k RUs
-                taskCount = currentCollectionThroughput / 1000;
-                if (taskCount >= 250)
-                {
-                    taskCount = 250;
-                }
+                // set TaskCount = 10 for each 10k RUs, minimum 1, maximum 250
+                taskCount = Math.Max(currentCollectionThroughput / 1000, 1);
+                taskCount = Math.Min(taskCount, 250);
             }
             else
             {


### PR DESCRIPTION
if currentCollectionThroughput is less than 1000, taskCount became 0, so we get DivideByZero when calculating numberOfDocumentsToInsert and also have zero tasks added later even if we fix this exception.

For DocumentDB minimum is 400. 