### PR TITLE
Adding a lease prefix to the change feed host options.

### DIFF
--- a/samples/ChangeFeedProcessor/DocumentDB.ChangeFeedProcessor/ChangeFeedEventHost.cs
+++ b/samples/ChangeFeedProcessor/DocumentDB.ChangeFeedProcessor/ChangeFeedEventHost.cs
@@ -476,7 +476,7 @@ namespace DocumentDB.ChangeFeedProcessor
             this.collectionSelfLink = collection.SelfLink;
 
             // Grab the options-supplied prefix if present otherwise leave it empty.
-            string optionsPrefix = string.IsNullOrWhiteSpace(this.options.LeasePrefix) ? string.Empty : this.options.LeasePrefix;
+            string optionsPrefix = this.options.LeasePrefix ?? string.Empty;
 
             // Beyond this point all access to collection is done via this self link: if collection is removed, we won't access new one using same name by accident.
             this.leasePrefix = string.Format(CultureInfo.InvariantCulture, "{0}{1}_{2}_{3}", optionsPrefix, this.collectionLocation.Uri.Host, database.ResourceId, collection.ResourceId);

--- a/samples/ChangeFeedProcessor/DocumentDB.ChangeFeedProcessor/ChangeFeedEventHost.cs
+++ b/samples/ChangeFeedProcessor/DocumentDB.ChangeFeedProcessor/ChangeFeedEventHost.cs
@@ -475,8 +475,11 @@ namespace DocumentDB.ChangeFeedProcessor
             DocumentCollection collection = collectionResponse.Resource;
             this.collectionSelfLink = collection.SelfLink;
 
-            // Beyond this point all access to colleciton is done via this self link: if collection is removed, we won't access new one using same name by accident.
-            this.leasePrefix = string.Format(CultureInfo.InvariantCulture, "{0}_{1}_{2}", this.collectionLocation.Uri.Host, database.ResourceId, collection.ResourceId);
+            // Grab the options-supplied prefix if present otherwise leave it empty.
+            string optionsPrefix = string.IsNullOrWhiteSpace(this.options.LeasePrefix) ? string.Empty : this.options.LeasePrefix + "_";
+
+            // Beyond this point all access to collection is done via this self link: if collection is removed, we won't access new one using same name by accident.
+            this.leasePrefix = string.Format(CultureInfo.InvariantCulture, "{0}{1}_{2}_{3}", optionsPrefix, this.collectionLocation.Uri.Host, database.ResourceId, collection.ResourceId);
 
             var leaseManager = new DocumentServiceLeaseManager(
                 this.auxCollectionLocation, 

--- a/samples/ChangeFeedProcessor/DocumentDB.ChangeFeedProcessor/ChangeFeedEventHost.cs
+++ b/samples/ChangeFeedProcessor/DocumentDB.ChangeFeedProcessor/ChangeFeedEventHost.cs
@@ -476,7 +476,7 @@ namespace DocumentDB.ChangeFeedProcessor
             this.collectionSelfLink = collection.SelfLink;
 
             // Grab the options-supplied prefix if present otherwise leave it empty.
-            string optionsPrefix = string.IsNullOrWhiteSpace(this.options.LeasePrefix) ? string.Empty : this.options.LeasePrefix + "_";
+            string optionsPrefix = string.IsNullOrWhiteSpace(this.options.LeasePrefix) ? string.Empty : this.options.LeasePrefix;
 
             // Beyond this point all access to collection is done via this self link: if collection is removed, we won't access new one using same name by accident.
             this.leasePrefix = string.Format(CultureInfo.InvariantCulture, "{0}{1}_{2}_{3}", optionsPrefix, this.collectionLocation.Uri.Host, database.ResourceId, collection.ResourceId);

--- a/samples/ChangeFeedProcessor/DocumentDB.ChangeFeedProcessor/ChangeFeedHostOptions.cs
+++ b/samples/ChangeFeedProcessor/DocumentDB.ChangeFeedProcessor/ChangeFeedHostOptions.cs
@@ -46,6 +46,12 @@ namespace DocumentDB.ChangeFeedProcessor
         /// Gets or sets the the frequency how often to checkpoint leases.
         /// </summary>
         public CheckpointFrequency CheckpointFrequency { get; set; }
+        
+        /// <summary>
+        /// Gets or sets a prefix to be used as part of the lease id. This can be used to support multiple <see cref="ChangeFeedEventHost"/> 
+        /// instances pointing at the same feed while using the same auxiliary collection.
+        /// </summary>
+        public string LeasePrefix { get; set; }
 
         /// <summary>
         /// Gets or set the minimum partition count for the host.


### PR DESCRIPTION
This adds support for pointing multiple hosts at the same collection using only one auxiliary collection