### PR TITLE
Improve handling of task cancelled exception.

### DIFF
--- a/samples/ChangeFeedProcessor/DocumentDB.ChangeFeedProcessor/ChangeFeedEventHost.cs
+++ b/samples/ChangeFeedProcessor/DocumentDB.ChangeFeedProcessor/ChangeFeedEventHost.cs
@@ -81,7 +81,7 @@ namespace DocumentDB.ChangeFeedProcessor
     /// </example>
     public class ChangeFeedEventHost : IPartitionObserver<DocumentServiceLease>
     {
-        const string DefaultUserAgentSuffix = "changefeed-0.2";
+        const string DefaultUserAgentSuffix = "changefeed-0.4";
         const string LeaseContainerName = "docdb-changefeed";
         const string LSNPropertyName = "_lsn";
 
@@ -297,132 +297,143 @@ namespace DocumentDB.ChangeFeedProcessor
 
                     string lastContinuation = options.RequestContinuation;
 
-                    try
+                    while (this.isShutdown == 0)
                     {
-                        while (this.isShutdown == 0)
+                        do
                         {
-                            do
+                            ExceptionDispatchInfo exceptionDispatchInfo = null;
+                            FeedResponse<Document> response = null;
+
+                            try
                             {
-                                ExceptionDispatchInfo exceptionDispatchInfo = null;
-                                FeedResponse<Document> response = null;
+                                response = await query.ExecuteNextAsync<Document>();
+                                lastContinuation = response.ResponseContinuation;
+                            }
+                            catch (DocumentClientException ex)
+                            {
+                                exceptionDispatchInfo = ExceptionDispatchInfo.Capture(ex);
+                            }
 
-                                try
+                            if (exceptionDispatchInfo != null)
+                            {
+                                DocumentClientException dcex = (DocumentClientException)exceptionDispatchInfo.SourceException;
+
+                                if (StatusCode.NotFound == (StatusCode)dcex.StatusCode && SubStatusCode.ReadSessionNotAvailable != (SubStatusCode)GetSubStatusCode(dcex))
                                 {
-                                    response = await query.ExecuteNextAsync<Document>();
-                                    lastContinuation = response.ResponseContinuation;
+                                    // Most likely, the database or collection was removed while we were enumerating.
+                                    // Shut down. The user will need to start over.
+                                    // Note: this has to be a new task, can't await for shutdown here, as shudown awaits for all worker tasks.
+                                    TraceLog.Error(string.Format("Partition {0}: resource gone (subStatus={1}). Aborting.", context.PartitionKeyRangeId, GetSubStatusCode(dcex)));
+                                    await Task.Factory.StartNew(() => this.StopAsync(ChangeFeedObserverCloseReason.ResourceGone));
+                                    break;
                                 }
-                                catch (DocumentClientException ex)
+                                else if (StatusCode.Gone == (StatusCode)dcex.StatusCode)
                                 {
-                                    exceptionDispatchInfo = ExceptionDispatchInfo.Capture(ex);
-                                }
-
-                                if (exceptionDispatchInfo != null)
-                                {
-                                    DocumentClientException dcex = (DocumentClientException)exceptionDispatchInfo.SourceException;
-
-                                    if (StatusCode.NotFound == (StatusCode)dcex.StatusCode && SubStatusCode.ReadSessionNotAvailable != (SubStatusCode)GetSubStatusCode(dcex))
+                                    SubStatusCode subStatusCode = (SubStatusCode)GetSubStatusCode(dcex);
+                                    if (SubStatusCode.PartitionKeyRangeGone == subStatusCode)
                                     {
-                                        // Most likely, the database or collection was removed while we were enumerating.
-                                        // Shut down. The user will need to start over.
-                                        // Note: this has to be a new task, can't await for shutdown here, as shudown awaits for all worker tasks.
-                                        TraceLog.Error(string.Format("Partition {0}: resource gone (subStatus={1}). Aborting.", context.PartitionKeyRangeId, GetSubStatusCode(dcex)));
-                                        await Task.Factory.StartNew(() => this.StopAsync(ChangeFeedObserverCloseReason.ResourceGone));
-                                        break;
+                                        bool isSuccess = await HandleSplitAsync(context.PartitionKeyRangeId, lastContinuation, lease.Id);
+                                        if (!isSuccess)
+                                        {
+                                            TraceLog.Error(string.Format("Partition {0}: HandleSplit failed! Aborting.", context.PartitionKeyRangeId));
+                                            await Task.Factory.StartNew(() => this.StopAsync(ChangeFeedObserverCloseReason.ResourceGone));
+                                            break;
+                                        }
+
+                                        // Throw LeaseLostException so that we take the lease down.
+                                        throw new LeaseLostException(lease, exceptionDispatchInfo.SourceException, true);
                                     }
-                                    else if (StatusCode.Gone == (StatusCode)dcex.StatusCode)
+                                    else if (SubStatusCode.Splitting == subStatusCode)
                                     {
-                                        SubStatusCode subStatusCode = (SubStatusCode)GetSubStatusCode(dcex);
-                                        if (SubStatusCode.PartitionKeyRangeGone == subStatusCode)
-                                        {
-                                            bool isSuccess = await HandleSplitAsync(context.PartitionKeyRangeId, lastContinuation, lease.Id);
-                                            if (!isSuccess)
-                                            {
-                                                TraceLog.Error(string.Format("Partition {0}: HandleSplit failed! Aborting.", context.PartitionKeyRangeId));
-                                                await Task.Factory.StartNew(() => this.StopAsync(ChangeFeedObserverCloseReason.ResourceGone));
-                                                break;
-                                            }
-
-                                            // Throw LeaseLostException so that we take the lease down.
-                                            throw new LeaseLostException(lease, exceptionDispatchInfo.SourceException, true);
-                                        }
-                                        else if (SubStatusCode.Splitting == subStatusCode)
-                                        {
-                                            TraceLog.Warning(string.Format("Partition {0} is splitting. Will retry to read changes until split finishes. {1}", context.PartitionKeyRangeId, dcex.Message));
-                                        }
-                                        else
-                                        {
-                                            exceptionDispatchInfo.Throw();
-                                        }
-                                    }
-                                    else if (StatusCode.TooManyRequests == (StatusCode)dcex.StatusCode ||
-                                        StatusCode.ServiceUnavailable == (StatusCode)dcex.StatusCode)
-                                    {
-                                        TraceLog.Warning(string.Format("Partition {0}: retriable exception : {1}", context.PartitionKeyRangeId, dcex.Message));
+                                        TraceLog.Warning(string.Format("Partition {0} is splitting. Will retry to read changes until split finishes. {1}", context.PartitionKeyRangeId, dcex.Message));
                                     }
                                     else
                                     {
                                         exceptionDispatchInfo.Throw();
                                     }
-
-                                    await Task.Delay(dcex.RetryAfter != TimeSpan.Zero ? dcex.RetryAfter : this.options.FeedPollDelay, cancellation.Token);
                                 }
-
-                                if (response != null)
+                                else if (StatusCode.TooManyRequests == (StatusCode)dcex.StatusCode ||
+                                    StatusCode.ServiceUnavailable == (StatusCode)dcex.StatusCode)
                                 {
-                                    if (response.Count > 0)
-                                    {
-                                        List<Document> docs = new List<Document>();
-                                        docs.AddRange(response);
+                                    TraceLog.Warning(string.Format("Partition {0}: retriable exception : {1}", context.PartitionKeyRangeId, dcex.Message));
+                                }
+                                else
+                                {
+                                    exceptionDispatchInfo.Throw();
+                                }
 
-                                        try
-                                        {
-                                            context.FeedResponse = response;
-                                            await observer.ProcessChangesAsync(context, docs);
-                                        }
-                                        catch (Exception ex)
-                                        {
-                                            TraceLog.Error(string.Format("IChangeFeedObserver.ProcessChangesAsync exception: {0}", ex));
-                                            closeReason = ChangeFeedObserverCloseReason.ObserverError;
-                                            throw;
-                                        }
-                                        finally
-                                        {
-                                            context.FeedResponse = null;
-                                        }
+                                await Task.Delay(dcex.RetryAfter != TimeSpan.Zero ? dcex.RetryAfter : this.options.FeedPollDelay, cancellation.Token);
+                            }
+
+                            if (response != null)
+                            {
+                                if (response.Count > 0)
+                                {
+                                    List<Document> docs = new List<Document>();
+                                    docs.AddRange(response);
+
+                                    try
+                                    {
+                                        context.FeedResponse = response;
+                                        await observer.ProcessChangesAsync(context, docs);
                                     }
-
-                                    checkpointStats.ProcessedDocCount += (uint)response.Count;
-
-                                    if (IsCheckpointNeeded(lease, checkpointStats))
+                                    catch (Exception ex)
                                     {
-                                        lease = await CheckpointAsync(lease, response.ResponseContinuation, context);
-                                        checkpointStats.Reset();
+                                        TraceLog.Error(string.Format("IChangeFeedObserver.ProcessChangesAsync exception: {0}", ex));
+                                        closeReason = ChangeFeedObserverCloseReason.ObserverError;
+                                        throw;
                                     }
-                                    else if (response.Count > 0)
+                                    finally
                                     {
-                                        TraceLog.Informational(string.Format("Checkpoint: not checkpointing for partition {0}, {1} docs, new continuation '{2}' as frequency condition is not met", lease.PartitionId, response.Count, response.ResponseContinuation));
+                                        context.FeedResponse = null;
                                     }
                                 }
-                            }
-                            while (query.HasMoreResults && this.isShutdown == 0);
 
-                            if (this.isShutdown == 0)
-                            {
-                                await Task.Delay(this.options.FeedPollDelay, cancellation.Token);
-                            }
-                        } // Outer while (this.isShutdown == 0) loop.
+                                checkpointStats.ProcessedDocCount += (uint)response.Count;
 
-                        closeReason = ChangeFeedObserverCloseReason.Shutdown;
-                    }
-                    catch (TaskCanceledException)
-                    {
-                        Debug.Assert(cancellation.IsCancellationRequested, "cancellation.IsCancellationRequested");
-                        TraceLog.Informational(string.Format("Cancel signal received for partition {0} worker!", context.PartitionKeyRangeId));
-                    }
+                                if (IsCheckpointNeeded(lease, checkpointStats))
+                                {
+                                    lease = await CheckpointAsync(lease, response.ResponseContinuation, context);
+                                    checkpointStats.Reset();
+                                }
+                                else if (response.Count > 0)
+                                {
+                                    TraceLog.Informational(string.Format("Checkpoint: not checkpointing for partition {0}, {1} docs, new continuation '{2}' as frequency condition is not met", lease.PartitionId, response.Count, response.ResponseContinuation));
+                                }
+                            }
+                        }
+                        while (query.HasMoreResults && this.isShutdown == 0);
+
+                        if (this.isShutdown == 0)
+                        {
+                            await Task.Delay(this.options.FeedPollDelay, cancellation.Token);
+                        }
+                    } // Outer while (this.isShutdown == 0) loop.
+
+                    closeReason = ChangeFeedObserverCloseReason.Shutdown;
                 }
                 catch (LeaseLostException ex)
                 {
                     closeReason = ex.IsGone ? ChangeFeedObserverCloseReason.LeaseGone : ChangeFeedObserverCloseReason.LeaseLost;
+                }
+                catch (TaskCanceledException ex)
+                {
+                    if (cancellation.IsCancellationRequested || this.isShutdown != 0)
+                    {
+                        TraceLog.Informational(string.Format("Cancel signal received for partition {0} worker!", context.PartitionKeyRangeId));
+                        if (!closeReason.HasValue)
+                        {
+                            closeReason = ChangeFeedObserverCloseReason.Shutdown;
+                        }
+                    }
+                    else
+                    {
+                        TraceLog.Warning(string.Format("Partition {0}: got task cancelled exception in non-shutdown scenario [cancellation={1}, isShutdown={2}], {3}", context.PartitionKeyRangeId, cancellation.IsCancellationRequested, this.isShutdown, ex.StackTrace));
+                        if (!closeReason.HasValue)
+                        {
+                            closeReason = ChangeFeedObserverCloseReason.Unknown;
+                        }
+                    }
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
For some reason github shows lots of changes due to whitespace. What's inside main loop hasn't changed. But try-catch around the loop is removed, thus code inside loop shifted 4 spaces to the left. 

It would be nice from github to give an option ignoring whitespace, but alas.